### PR TITLE
SLING-9395 Support bundle updates in api regions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </parent>
 
     <artifactId>org.apache.sling.feature.apiregions</artifactId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Apache Sling Feature API Regions Runtime</name>

--- a/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
+++ b/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
@@ -28,6 +28,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 
 import org.osgi.framework.Bundle;
@@ -40,6 +42,7 @@ import org.osgi.framework.wiring.BundleRevision;
 
 class ResolverHookImpl implements ResolverHook {
 
+    final ConcurrentMap<String, Set<String>> bundleLocationFeatureMap = new ConcurrentHashMap<>();
     final RegionConfiguration configuration;
 
     ResolverHookImpl(RegionConfiguration cfg) {
@@ -64,31 +67,17 @@ class ResolverHookImpl implements ResolverHook {
 
         Bundle reqBundle = requirement.getRevision().getBundle();
         long reqBundleID = reqBundle.getBundleId();
-        String reqBundleName = reqBundle.getSymbolicName();
-        Version reqBundleVersion = reqBundle.getVersion();
 
         Set<String> reqRegions = new HashSet<>(this.configuration.getDefaultRegions());
-        List<String> reqFeatures = new ArrayList<>();
-        List<String> aids = this.configuration.getBsnVerMap().get(new AbstractMap.SimpleEntry<String, Version>(reqBundleName, reqBundleVersion));
-        if (aids != null) {
-            for (String aid : aids) {
-                Set<String> fid = this.configuration.getBundleFeatureMap().get(aid);
-                if (fid != null)
-                    reqFeatures.addAll(fid);
+        Set<String> reqFeatures = getFeaturesForBundle(reqBundle);
+        for (String feature : reqFeatures) {
+            Set<String> fr = this.configuration.getFeatureRegionMap().get(feature);
+            if (fr != null) {
+                reqRegions.addAll(fr);
             }
-
-            for (String feature : reqFeatures) {
-                Set<String> fr = this.configuration.getFeatureRegionMap().get(feature);
-                if (fr != null) {
-                    reqRegions.addAll(fr);
-                }
-            }
-        } else {
-            // Bundle is not coming from a feature
         }
 
         Map<BundleCapability, String> coveredCaps = new HashMap<>();
-
         Map<BundleCapability, String> bcFeatureMap = new HashMap<>();
         String packageName = null;
         nextCapability:
@@ -109,25 +98,15 @@ class ResolverHookImpl implements ResolverHook {
                 continue nextCapability;
             }
 
-            String capBundleName = capBundle.getSymbolicName();
-            Version capBundleVersion = capBundle.getVersion();
-
-            List<String> capBundleArtifacts = this.configuration.getBsnVerMap().get(new AbstractMap.SimpleEntry<String, Version>(capBundleName, capBundleVersion));
-            if (capBundleArtifacts == null) {
+            Set<String> capFeatures = getFeaturesForBundle(capBundle);
+            if (capFeatures.isEmpty()) {
                 // Capability is not in any feature, everyone can access
                 coveredCaps.put(bc, RegionConstants.GLOBAL_REGION);
                 continue nextCapability;
             }
 
-            List<String> capFeatures = new ArrayList<>();
-            for (String ba : capBundleArtifacts) {
-                Set<String> capfeats = this.configuration.getBundleFeatureMap().get(ba);
-                if (capfeats != null)
-                    capFeatures.addAll(capfeats);
-            }
-
             if (capFeatures.isEmpty())
-                capFeatures = Collections.singletonList(null);
+                capFeatures = Collections.singleton(null);
 
             for (String capFeat : capFeatures) {
                 if (capFeat == null) {
@@ -263,6 +242,32 @@ class ResolverHookImpl implements ResolverHook {
                 it.remove();
             }
         }
+    }
+
+    Set<String> getFeaturesForBundle(Bundle bundle) {
+        Set<String> features = bundleLocationFeatureMap.get(bundle.getLocation());
+        if (features != null)
+            return features;
+
+        Set<String> newSet = new HashSet<>();
+        String bundleName = bundle.getSymbolicName();
+        Version bundleVersion = bundle.getVersion();
+        List<String> aids = this.configuration.getBsnVerMap().get(
+                new AbstractMap.SimpleEntry<String, Version>(bundleName, bundleVersion));
+        if (aids != null) {
+            for (String aid : aids) {
+                Set<String> fid = this.configuration.getBundleFeatureMap().get(aid);
+                if (fid != null)
+                    newSet.addAll(fid);
+            }
+        }
+
+        Set<String> res = Collections.unmodifiableSet(newSet);
+        Set<String> prev = bundleLocationFeatureMap.putIfAbsent(bundle.getLocation(), res);
+        if (prev != null)
+            return prev;
+        else
+            return res;
     }
 
     List<String> getRegionsForPackage(String packageName, String feature) {

--- a/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
+++ b/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
@@ -245,10 +245,11 @@ class ResolverHookImpl implements ResolverHook {
     }
 
     Set<String> getFeaturesForBundle(Bundle bundle) {
-        Set<String> features = bundleLocationFeatureMap.get(bundle.getLocation());
-        if (features != null)
-            return features;
+        return bundleLocationFeatureMap.computeIfAbsent(bundle.getLocation(),
+                l -> getFeaturesForBundleFromConfig(bundle));
+    }
 
+    private Set<String> getFeaturesForBundleFromConfig(Bundle bundle) {
         Set<String> newSet = new HashSet<>();
         String bundleName = bundle.getSymbolicName();
         Version bundleVersion = bundle.getVersion();
@@ -262,12 +263,7 @@ class ResolverHookImpl implements ResolverHook {
             }
         }
 
-        Set<String> res = Collections.unmodifiableSet(newSet);
-        Set<String> prev = bundleLocationFeatureMap.putIfAbsent(bundle.getLocation(), res);
-        if (prev != null)
-            return prev;
-        else
-            return res;
+        return Collections.unmodifiableSet(newSet);
     }
 
     List<String> getRegionsForPackage(String packageName, String feature) {


### PR DESCRIPTION
The algorithm to find what feature(s) a bundle belongs to at runtime is
now the following:
1. Find the features a bundle belongs to by looking up the
bundle-location to features association.
2. If the bundle location is not associated with any features yet, look
up the bsn+version from the initial, defined list, and associate the
bundle location with the features found there.
This means that if the bundle is later updated, the bundle will still be
associated with the features it was initially associated with and will
therefore still be in the region that it was originally in, even though
its version might have changed. The update must be done through
Bundle.update() or Bundle.update(InputStream) so that the bundle's
location doesn't change..