### PR TITLE
SLING-9395 Support bundle updates in api regions

### DIFF
--- a/src/main/java/org/apache/sling/feature/apiregions/impl/Activator.java
+++ b/src/main/java/org/apache/sling/feature/apiregions/impl/Activator.java
@@ -71,6 +71,10 @@ public class Activator implements BundleActivator, FrameworkListener {
     @Override
     public synchronized void stop(BundleContext context) throws Exception {
         // All services automatically get unregistered by the framework.
+
+        if (configuration != null) {
+            configuration.storePersistedConfiguration(context);
+        }
     }
 
     private void createConfiguration() {

--- a/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
+++ b/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
@@ -28,8 +28,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 
 import org.osgi.framework.Bundle;
@@ -42,7 +40,6 @@ import org.osgi.framework.wiring.BundleRevision;
 
 class ResolverHookImpl implements ResolverHook {
 
-    final ConcurrentMap<String, Set<String>> bundleLocationFeatureMap = new ConcurrentHashMap<>();
     final RegionConfiguration configuration;
 
     ResolverHookImpl(RegionConfiguration cfg) {
@@ -245,8 +242,8 @@ class ResolverHookImpl implements ResolverHook {
     }
 
     Set<String> getFeaturesForBundle(Bundle bundle) {
-        return bundleLocationFeatureMap.computeIfAbsent(bundle.getLocation(),
-                l -> getFeaturesForBundleFromConfig(bundle));
+        return this.configuration.getBundleLocationFeatureMap()
+                .computeIfAbsent(bundle.getLocation(), l -> getFeaturesForBundleFromConfig(bundle));
     }
 
     private Set<String> getFeaturesForBundleFromConfig(Bundle bundle) {

--- a/src/test/java/org/apache/sling/feature/apiregions/impl/ActivatorTest.java
+++ b/src/test/java/org/apache/sling/feature/apiregions/impl/ActivatorTest.java
@@ -84,6 +84,7 @@ public class ActivatorTest {
         expectedProps.put(REGION_PACKAGE_FILENAME, new File(r).toURI().toString());
 
         BundleContext bc = Mockito.mock(BundleContext.class);
+        Mockito.when(bc.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(bc.getProperty(Activator.REGIONS_PROPERTY_NAME)).thenReturn("*");
         Mockito.when(bc.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).
             thenReturn(i);

--- a/src/test/java/org/apache/sling/feature/apiregions/impl/RegionConfigurationTest.java
+++ b/src/test/java/org/apache/sling/feature/apiregions/impl/RegionConfigurationTest.java
@@ -44,9 +44,11 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Version;
 import org.osgi.framework.hooks.resolver.ResolverHook;
@@ -69,6 +71,7 @@ public class RegionConfigurationTest {
         String e = getClass().getResource("/empty.properties").toURI().toString();
         String f = getClass().getResource("/idbsnver1.properties").toURI().toString();
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).thenReturn(f);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + FEATURE_REGION_FILENAME)).thenReturn(e);
@@ -88,6 +91,7 @@ public class RegionConfigurationTest {
         String e = getClass().getResource("/empty.properties").toURI().toString();
         String f = getClass().getResource("/idbsnver1.properties").toURI().toString();
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).thenReturn(f);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + FEATURE_REGION_FILENAME)).thenReturn(e);
@@ -119,6 +123,7 @@ public class RegionConfigurationTest {
         String e = getClass().getResource("/empty.properties").toURI().toString();
         String f = getClass().getResource("/bundles1.properties").toURI().toString();
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).thenReturn(f);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + FEATURE_REGION_FILENAME)).thenReturn(e);
@@ -140,6 +145,7 @@ public class RegionConfigurationTest {
         String e = getClass().getResource("/empty.properties").toURI().toString();
         String f = getClass().getResource("/bundles1.properties").toURI().toString();
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).thenReturn(f);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + FEATURE_REGION_FILENAME)).thenReturn(e);
@@ -175,6 +181,7 @@ public class RegionConfigurationTest {
         String e = getClass().getResource("/empty.properties").toURI().toString();
         String f = getClass().getResource("/features1.properties").toURI().toString();
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + FEATURE_REGION_FILENAME)).thenReturn(f);
@@ -194,6 +201,7 @@ public class RegionConfigurationTest {
         String e = getClass().getResource("/empty.properties").toURI().toString();
         String f = getClass().getResource("/features1.properties").toURI().toString();
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + FEATURE_REGION_FILENAME)).thenReturn(f);
@@ -225,6 +233,7 @@ public class RegionConfigurationTest {
         String e = getClass().getResource("/empty.properties").toURI().toString();
         String f = getClass().getResource("/regions1.properties").toURI().toString();
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + FEATURE_REGION_FILENAME)).thenReturn(e);
@@ -244,6 +253,7 @@ public class RegionConfigurationTest {
         String e = getClass().getResource("/empty.properties").toURI().toString();
         String f = getClass().getResource("/regions1.properties").toURI().toString();
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + FEATURE_REGION_FILENAME)).thenReturn(e);
@@ -273,6 +283,7 @@ public class RegionConfigurationTest {
         String e = getClass().getResource("/empty.properties").toURI().toString();
         String f = getClass().getResource("/regions2.properties").toURI().toString();
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(APIREGIONS_JOINGLOBAL)).thenReturn("obsolete,deprecated");
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).thenReturn(e);
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).thenReturn(e);
@@ -288,6 +299,7 @@ public class RegionConfigurationTest {
     @Test
     public void testBegin() throws Exception {
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + IDBSNVER_FILENAME)).
             thenReturn(getClass().getResource("/idbsnver1.properties").toURI().toString());
         Mockito.when(ctx.getProperty(PROPERTIES_RESOURCE_PREFIX + BUNDLE_FEATURE_FILENAME)).
@@ -313,6 +325,7 @@ public class RegionConfigurationTest {
     @Test
     public void testURLs() throws Exception {
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         String location = new File(getClass().getResource("/props1/idbsnver.properties").
                 getFile()).getParentFile().toURI().toString();
         Mockito.when(ctx.getProperty(PROPERTIES_FILE_LOCATION)).thenReturn(location);
@@ -327,6 +340,7 @@ public class RegionConfigurationTest {
     @Test
     public void testClassloaderURLs() throws Exception {
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_FILE_LOCATION)).
             thenReturn("classloader://props1");
 
@@ -340,6 +354,7 @@ public class RegionConfigurationTest {
     @Test
     public void testOrderingOfRegionsInFeatures() throws Exception {
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_FILE_LOCATION)).
             thenReturn("classloader://props2");
 
@@ -351,6 +366,7 @@ public class RegionConfigurationTest {
     @Test
     public void testUnModifiableMaps() throws Exception {
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(PROPERTIES_FILE_LOCATION)).
             thenReturn("classloader://props1");
 
@@ -373,9 +389,39 @@ public class RegionConfigurationTest {
         testDefaultRegions(null, Collections.emptySet());
     }
 
+    @Test
+    public void testStoreLoadPersistedConfig() throws Exception {
+        File f = File.createTempFile("testStorePersistedConfig", ".tmp");
+
+        try {
+            Bundle bundle = Mockito.mock(Bundle.class);
+            Mockito.when(bundle.getDataFile("bundleLocationToFeature.properties"))
+                .thenReturn(f);
+
+            BundleContext ctx = Mockito.mock(BundleContext.class);
+            Mockito.when(ctx.getBundle()).thenReturn(bundle);
+            Mockito.when(ctx.getProperty(PROPERTIES_FILE_LOCATION)).
+                thenReturn("classloader://props1");
+
+            RegionConfiguration cfg = new RegionConfiguration(ctx);
+
+            ConcurrentMap<String, Set<String>> m = cfg.getBundleLocationFeatureMap();
+            m.put("foo://bar", Collections.singleton("blah"));
+            m.put("foo://tar", new HashSet<>(Arrays.asList("a", "b", "c")));
+            cfg.storePersistedConfiguration(ctx);
+
+            RegionConfiguration cfg2 = new RegionConfiguration(ctx);
+            ConcurrentMap<String, Set<String>> m2 = cfg2.getBundleLocationFeatureMap();
+            assertEquals(m, m2);
+        } finally {
+            f.delete();
+        }
+    }
+
     private void testDefaultRegions(String defProp, Set<String> expected)
             throws IOException, URISyntaxException, NoSuchFieldException, IllegalAccessException {
         BundleContext ctx = Mockito.mock(BundleContext.class);
+        Mockito.when(ctx.getBundle()).thenReturn(Mockito.mock(Bundle.class));
         Mockito.when(ctx.getProperty(DEFAULT_REGIONS)).thenReturn(defProp);
         Mockito.when(ctx.getProperty(PROPERTIES_FILE_LOCATION)).
         thenReturn("classloader://props1");


### PR DESCRIPTION
Keep the bundle location to features association in the
RegionConfiguration class so it's kept between resolve phases. It's also
persisted in a file in bundle private storage. Loaded on
Activator.start() and stored on Activator.stop()