### PR TITLE
SLING-9410 BSN to feature cache does not get updated when new configuration arrives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
                         <exclude>src/test/resources/props1/*</exclude>
                         <exclude>src/test/resources/props2/*</exclude>
                         <exclude>src/test/resources/props3/*</exclude>
+                        <exclude>src/test/resources/props4/*</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/src/main/java/org/apache/sling/feature/apiregions/impl/Activator.java
+++ b/src/main/java/org/apache/sling/feature/apiregions/impl/Activator.java
@@ -107,7 +107,7 @@ public class Activator implements BundleActivator, FrameworkListener {
         // All services automatically get unregistered by the framework.
 
         if (configuration != null) {
-            configuration.storePersistedConfiguration(context);
+            configuration.storeLocationToConfigMap(context);
         }
         if ( this.configAdminTracker != null ) {
             this.configAdminTracker.close();

--- a/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
+++ b/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
@@ -242,14 +242,18 @@ class ResolverHookImpl implements ResolverHook {
     }
 
     Set<String> getFeaturesForBundle(Bundle bundle) {
-        return this.configuration.getBundleLocationFeatureMap()
-                .computeIfAbsent(bundle.getLocation(), l -> getFeaturesForBundleFromConfig(bundle));
+        // Look up the bsn and bundle version initially associated with the location. If the bundle
+        // for the specified location was later updated, the initial bsn+version is still used to look up the
+        // api regions configuration
+        Map.Entry<String, Version> bsnVer = this.configuration.getBundleLocationConfigMap()
+                .computeIfAbsent(bundle.getLocation(), l -> new AbstractMap.SimpleEntry<>(
+                        bundle.getSymbolicName(), bundle.getVersion()));
+
+        return getFeaturesForBundleFromConfig(bsnVer.getKey(), bsnVer.getValue());
     }
 
-    private Set<String> getFeaturesForBundleFromConfig(Bundle bundle) {
+    private Set<String> getFeaturesForBundleFromConfig(String bundleName, Version bundleVersion) {
         Set<String> newSet = new HashSet<>();
-        String bundleName = bundle.getSymbolicName();
-        Version bundleVersion = bundle.getVersion();
         List<String> aids = this.configuration.getBsnVerMap().get(
                 new AbstractMap.SimpleEntry<String, Version>(bundleName, bundleVersion));
         if (aids != null) {

--- a/src/test/resources/props4/bundles.properties
+++ b/src/test/resources/props4/bundles.properties
@@ -1,0 +1,4 @@
+#Generated at Sat Nov 03 10:58:58 GMT 2018
+#Sat Nov 03 10:58:58 GMT 2018
+g\:b2\:1.2.3=org.sling\:something\:1.2.3
+g\:b1\:1=org.sling\:something\:1.2.3

--- a/src/test/resources/props4/features.properties
+++ b/src/test/resources/props4/features.properties
@@ -1,0 +1,3 @@
+#Generated at Sat Nov 03 11:10:29 GMT 2018
+#Sat Nov 03 11:10:29 GMT 2018
+org.sling\:something\:1.2.3=internal,global

--- a/src/test/resources/props4/idbsnver.properties
+++ b/src/test/resources/props4/idbsnver.properties
@@ -1,0 +1,5 @@
+#Generated at Sat Nov 03 10:26:37 GMT 2018
+#Sat Nov 03 10:26:37 GMT 2018
+g\:b2\:1.2.3=b2~1.2.3
+g\:b1\:1=b1~1.0.0
+

--- a/src/test/resources/props4/regions.properties
+++ b/src/test/resources/props4/regions.properties
@@ -1,0 +1,4 @@
+#Generated at Sat Nov 03 11:10:29 GMT 2018
+#Sat Nov 03 11:10:29 GMT 2018
+internal=xyz
+global=d.e.f,test,a.b.c


### PR DESCRIPTION
This is an alternative approach to #7 which is simpler because the location cache does not need to be pruned on a configuration update.

Thanks to @cziegeler for the suggestion of implementing it this way.

So we either merge #7 or this PR...