### PR TITLE
SLING-9521 Packages exported in earlier API Regions are not available to later API Regions

### DIFF
--- a/src/main/java/org/apache/sling/feature/apiregions/impl/RegionConfiguration.java
+++ b/src/main/java/org/apache/sling/feature/apiregions/impl/RegionConfiguration.java
@@ -37,7 +37,6 @@ import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -45,6 +44,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 
 import org.osgi.framework.BundleContext;
@@ -52,10 +52,11 @@ import org.osgi.framework.Version;
 
 class RegionConfiguration {
     private static final String BUNDLE_LOCATION_TO_FEATURE_FILE = "bundleLocationToFeature.properties";
+    private static final String REGION_ORDER = "__region.order__";
 
     volatile Map<Map.Entry<String, Version>, List<String>> bsnVerMap;
     volatile Map<String, Set<String>> bundleFeatureMap;
-    volatile Map<String, Set<String>> featureRegionMap;
+    volatile Map<String, List<String>> featureRegionMap;
     volatile Map<String, Set<String>> regionPackageMap;
 
     final Set<String> defaultRegions;
@@ -65,8 +66,9 @@ class RegionConfiguration {
 
     private final Map<Map.Entry<String, Version>, List<String>> baseBsnVerMap;
     private final Map<String, Set<String>> baseBundleFeatureMap;
-    private final Map<String, Set<String>> baseFeatureRegionMap;
+    private final Map<String, List<String>> baseFeatureRegionMap;
     private final Map<String, Set<String>> baseRegionPackageMap;
+    private final List<String> globalRegionOrder;
 
     // This field stores the association between bundle location and the configuration
     // to be used. The configuration is based on bsn+version. If the bundle is updated
@@ -78,13 +80,15 @@ class RegionConfiguration {
     private final String toGlobalConfig;
 
     RegionConfiguration(Map<Entry<String, Version>, List<String>> bsnVerMap, Map<String, Set<String>> bundleFeatureMap,
-                        Map<String, Set<String>> featureRegionMap, Map<String, Set<String>> regionPackageMap, Set<String> defaultRegions) {
+                        Map<String, List<String>> featureRegionMap, Map<String, Set<String>> regionPackageMap, Set<String> defaultRegions) {
         this.defaultRegions = defaultRegions;
 
         this.baseBsnVerMap = new HashMap<>(bsnVerMap);
         this.baseBundleFeatureMap = new HashMap<>(bundleFeatureMap);
         this.baseFeatureRegionMap = new HashMap<>(featureRegionMap);
         this.baseRegionPackageMap = new HashMap<>(regionPackageMap);
+        this.globalRegionOrder = new ArrayList<>(this.baseFeatureRegionMap.getOrDefault(REGION_ORDER, Collections.emptyList()));
+        this.baseFeatureRegionMap.remove(REGION_ORDER);
 
         this.toGlobalConfig = null;
 
@@ -106,7 +110,7 @@ class RegionConfiguration {
         URI featuresFile = getDataFileURI(context, RegionConstants.FEATURE_REGION_FILENAME);
         // Register the location as a service property for diagnostic purposes
         regProps.put(RegionConstants.FEATURE_REGION_FILENAME, featuresFile.toString());
-        Map<String, Set<String>> frm = populateFeatureRegionMap(featuresFile);
+        Map<String, List<String>> frm = populateFeatureRegionMap(featuresFile);
 
         URI regionsFile = getDataFileURI(context, RegionConstants.REGION_PACKAGE_FILENAME);
         // Register the location as a service property for diagnostic purposes
@@ -118,6 +122,8 @@ class RegionConfiguration {
         this.baseBundleFeatureMap = bfm;
         this.baseFeatureRegionMap = frm;
         this.baseRegionPackageMap = rpm;
+        this.globalRegionOrder = new ArrayList<>(this.baseFeatureRegionMap.getOrDefault(REGION_ORDER, Collections.emptyList()));
+        this.baseFeatureRegionMap.remove(REGION_ORDER);
 
         this.toGlobalConfig = context.getProperty(RegionConstants.APIREGIONS_JOINGLOBAL);
         if ( this.toGlobalConfig != null ) {
@@ -206,7 +212,7 @@ class RegionConfiguration {
     private synchronized void updateConfiguration() {
         final Map<Entry<String, Version>, List<String>> bvm = cloneMapOfLists(this.baseBsnVerMap);
         final Map<String, Set<String>> bfm = cloneMapOfSets(this.baseBundleFeatureMap);
-        final Map<String, Set<String>> frm = cloneMapOfSets(this.baseFeatureRegionMap);
+        final Map<String, List<String>> frm = cloneMapOfLists(this.baseFeatureRegionMap);
         final Map<String, Set<String>> rpm = cloneMapOfSets(this.baseRegionPackageMap);
 
         // apply configurations
@@ -227,19 +233,19 @@ class RegionConfiguration {
             // bundle id to features
             valObj = props.get(RegionConstants.PROP_bundleFeatures);
             if ( valObj != null ) {
-                handleMapConfig(valObj, bfm);
+                handleMapConfig(valObj, bfm, HashSet::new);
             }
 
             // feature id to regions
             valObj = props.get(RegionConstants.PROP_featureRegions);
             if ( valObj != null ) {
-                handleMapConfig(valObj, frm);
+                handleMapConfig(valObj, frm, ArrayList::new);
             }
 
             // region to packages
             valObj = props.get(RegionConstants.PROP_regionPackage);
             if ( valObj != null ) {
-                handleMapConfig(valObj, rpm);
+                handleMapConfig(valObj, rpm, HashSet::new);
             }
         }
 
@@ -251,16 +257,16 @@ class RegionConfiguration {
         // Make all maps and their contents unmodifiable
         bsnVerMap = unmodifiableMapToList(bvm);
         bundleFeatureMap = unmodifiableMapToSet(bfm);
-        featureRegionMap = unmodifiableMapToSet(frm);
+        featureRegionMap = unmodifiableMapToList(frm);
         regionPackageMap = unmodifiableMapToSet(rpm);
     }
 
-    private void handleMapConfig(Object valObj, Map<String, Set<String>> map) {
+    private <T extends Collection<String>> void handleMapConfig(Object valObj, Map<String, T> map, Supplier<T> constructor) {
         for(final String val : convert(valObj)) {
             final String[] parts = val.split("=");
             final String n = parts[0];
             final String[] features = parts[1].split(",");
-            addValuesToMap(map, n, Arrays.asList(features));
+            addValuesToMap(map, n, Arrays.asList(features), constructor);
         }
     }
 
@@ -275,7 +281,7 @@ class RegionConfiguration {
     private static <K,V> Map<K, Set<V>> cloneMapOfSets(Map<K, Set<V>> m) {
         final Map<K, Set<V>> newMap = new HashMap<>();
         for (Map.Entry<K, Set<V>> entry : m.entrySet()) {
-            newMap.put(entry.getKey(), new LinkedHashSet<>(entry.getValue()));
+            newMap.put(entry.getKey(), new HashSet<>(entry.getValue()));
         }
         return newMap;
     }
@@ -300,7 +306,7 @@ class RegionConfiguration {
             if (packages == null)
                 continue;
 
-            addValuesToMap(rpm, RegionConstants.GLOBAL_REGION, packages);
+            addValuesToMap(rpm, RegionConstants.GLOBAL_REGION, packages, HashSet::new);
             rpm.remove(region);
         }
     }
@@ -337,19 +343,19 @@ class RegionConfiguration {
     }
 
     private static Map<String, Set<String>> populateBundleFeatureMap(URI bundlesFile) throws IOException {
-        return loadMap(bundlesFile);
+        return loadMap(bundlesFile, HashSet::new);
     }
 
-    private static Map<String, Set<String>> populateFeatureRegionMap(URI featuresFile) throws IOException {
-        return loadMap(featuresFile);
+    private static Map<String, List<String>> populateFeatureRegionMap(URI featuresFile) throws IOException {
+        return loadMap(featuresFile, ArrayList::new);
     }
 
     private static Map<String, Set<String>> populateRegionPackageMap(URI regionsFile) throws IOException {
-        return loadMap(regionsFile);
+        return loadMap(regionsFile, HashSet::new);
     }
 
-    private static Map<String, Set<String>> loadMap(URI propsFile) throws IOException {
-        Map<String, Set<String>> m = new HashMap<>();
+    private static <T extends Collection<String>> Map<String, T> loadMap(URI propsFile, Supplier<T> constructor) throws IOException {
+        Map<String, T> m = new HashMap<>();
 
         Properties p = new Properties();
         try (InputStream is = propsFile.toURL().openStream()) {
@@ -358,16 +364,16 @@ class RegionConfiguration {
 
         for (String n : p.stringPropertyNames()) {
             String[] values = p.getProperty(n).split(",");
-            addValuesToMap(m, n, Arrays.asList(values));
+            addValuesToMap(m, n, Arrays.asList(values), constructor);
         }
 
         return m;
     }
 
-    private static void addValuesToMap(Map<String, Set<String>> map, String key, Collection<String> values) {
-        Set<String> bf = map.get(key);
+    private static <T extends Collection<String>> void addValuesToMap(Map<String, T> map, String key, Collection<String> values, Supplier<T> constructor) {
+        T bf = map.get(key);
         if (bf == null) {
-            bf = new LinkedHashSet<>(); // It's important that the insertion order is maintained.
+            bf = constructor.get();
             map.put(key, bf);
         }
         bf.addAll(values);
@@ -428,7 +434,7 @@ class RegionConfiguration {
         return bundleFeatureMap;
     }
 
-    public Map<String, Set<String>> getFeatureRegionMap() {
+    public Map<String, List<String>> getFeatureRegionMap() {
         return featureRegionMap;
     }
 
@@ -438,6 +444,10 @@ class RegionConfiguration {
 
     public Set<String> getDefaultRegions() {
         return defaultRegions;
+    }
+
+    public List<String> getGlobalRegionOrder() {
+        return globalRegionOrder;
     }
 
     public Dictionary<String, Object> getRegistrationProperties() {

--- a/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
+++ b/src/main/java/org/apache/sling/feature/apiregions/impl/ResolverHookImpl.java
@@ -78,7 +78,7 @@ class ResolverHookImpl implements ResolverHook {
         Set<String> bareReqRegions = null; // Null means: not opting into API Regions
         Set<String> reqFeatures = getFeaturesForBundle(reqBundle);
         for (String feature : reqFeatures) {
-            Set<String> fr = this.configuration.getFeatureRegionMap().get(feature);
+            List<String> fr = this.configuration.getFeatureRegionMap().get(feature);
             if (fr != null) {
                 if (bareReqRegions == null)
                     bareReqRegions = new HashSet<>();
@@ -131,7 +131,7 @@ class ResolverHookImpl implements ResolverHook {
                     continue nextCapability;
                 }
 
-                Set<String> capRegions = this.configuration.getFeatureRegionMap().get(capFeat);
+                List<String> capRegions = this.configuration.getFeatureRegionMap().get(capFeat);
                 if (capRegions == null || capRegions.size() == 0) {
                     // If the feature hosting the capability has no regions defined, everyone can access
                     coveredCaps.put(bc, RegionConstants.GLOBAL_REGION);
@@ -139,7 +139,7 @@ class ResolverHookImpl implements ResolverHook {
                 }
                 bcFeatureMap.put(bc, capFeat);
 
-                List<String> sharedRegions = new ArrayList<>(reqRegions);
+                List<String> sharedRegions = new ArrayList<>(getRegionsAndAncestors(reqRegions));
                 sharedRegions.retainAll(capRegions);
 
                 // Look at specific regions first as they take precedence over the global region
@@ -200,6 +200,28 @@ class ResolverHookImpl implements ResolverHook {
         }
     }
 
+    // Get the a set of the regions plus their ancestors. They are obtained from the global region order.
+    private Set<String> getRegionsAndAncestors(Set<String> regions) {
+        Set<String> s = new HashSet<>();
+
+        for (String region : regions) {
+            s.add(region);
+
+            if (configuration.getGlobalRegionOrder().contains(region)) {
+                for (String r : configuration.getGlobalRegionOrder()) {
+                    if (r.equals(region)) {
+                        break;
+                    }
+                    s.add(r);
+                }
+            } else {
+                Activator.LOG.log(Level.WARNING, "Global API Region order " + configuration.getGlobalRegionOrder() +
+                        " does not contain region: " + region);
+            }
+        }
+        return s;
+    }
+
     /**
      * Check if the package is exported in the global region
      * @param packageName The package
@@ -207,7 +229,7 @@ class ResolverHookImpl implements ResolverHook {
      * @return If the feature exports to the global region and the package is exported into the global region
      */
     private boolean isInGlobalRegion(String packageName, String capFeat) {
-        Set<String> capRegions = this.configuration.getFeatureRegionMap().get(capFeat);
+        List<String> capRegions = this.configuration.getFeatureRegionMap().get(capFeat);
         if (capRegions != null && capRegions.contains(RegionConstants.GLOBAL_REGION)) {
             Set<String> globalPackages = this.configuration.getRegionPackageMap().get(RegionConstants.GLOBAL_REGION);
             if (globalPackages.contains(packageName)) {
@@ -311,7 +333,7 @@ class ResolverHookImpl implements ResolverHook {
         if (packageName == null)
             return Collections.emptyList();
 
-        Set<String> regions = this.configuration.getFeatureRegionMap().get(feature);
+        List<String> regions = this.configuration.getFeatureRegionMap().get(feature);
         if (regions == null)
             return Collections.emptyList();
 

--- a/src/test/resources/features1.properties
+++ b/src/test/resources/features1.properties
@@ -1,4 +1,5 @@
 #Generated at Sat Nov 03 11:10:29 GMT 2018
 #Sat Nov 03 11:10:29 GMT 2018
 an.other\:feature\:123=global
-org.sling\:something\:1.2.3=internal,global
+org.sling\:something\:1.2.3=global,internal
+__region.order__=global,internal

--- a/src/test/resources/props1/features.properties
+++ b/src/test/resources/props1/features.properties
@@ -1,4 +1,5 @@
 #Generated at Sat Nov 03 11:10:29 GMT 2018
 #Sat Nov 03 11:10:29 GMT 2018
 an.other\:feature\:123=global
-org.sling\:something\:1.2.3=internal,global
+org.sling\:something\:1.2.3=global,internal
+__region.order__=global,internal

--- a/src/test/resources/props2/features.properties
+++ b/src/test/resources/props2/features.properties
@@ -1,3 +1,4 @@
 #Generated at Sat Nov 03 11:10:29 GMT 2018
 #Sat Nov 03 11:10:29 GMT 2018
 org.sling\:something\:1.2.3=r0,r1,r2,r3
+__region.order__=global,r0,r1,r2,r3

--- a/src/test/resources/props3/features.properties
+++ b/src/test/resources/props3/features.properties
@@ -1,4 +1,5 @@
 #Generated at Sat Nov 03 11:10:29 GMT 2018
 #Sat Nov 03 11:10:29 GMT 2018
 an.other\:feature\:123=global
-org.sling\:something\:1.2.3=internal,global
+org.sling\:something\:1.2.3=global,internal
+__region.order__=global,internal

--- a/src/test/resources/props4/features.properties
+++ b/src/test/resources/props4/features.properties
@@ -1,3 +1,4 @@
 #Generated at Sat Nov 03 11:10:29 GMT 2018
 #Sat Nov 03 11:10:29 GMT 2018
-org.sling\:something\:1.2.3=internal,global
+org.sling\:something\:1.2.3=global,internal
+__region.order__=global,internal


### PR DESCRIPTION
Added a property to the feature->regions map (features.properties) to
declare the global region order: __region.order__
The value format of __region.order__ is the same as the other entries in
the file: an ordered list of regions. This property lists the total
ordering of regions (while features might only have a partial list).
Since the values of the features.properties have significant ordering, I
also made this explicity my changing the signature of the
feature->regions map to have a List for the values.