### PR TITLE
SLING-10404 Log: 'No Configuration Admin API available' when it is available

### DIFF
--- a/src/main/java/org/apache/sling/feature/apiregions/impl/Activator.java
+++ b/src/main/java/org/apache/sling/feature/apiregions/impl/Activator.java
@@ -153,14 +153,14 @@ public class Activator implements BundleActivator, FrameworkListener {
                 return;
             }
 
-            Requirement cmReq = createPackageRequirement();
+            Requirement cmReq = createCMPackageRequirement();
 
             // Reflectively register a Configuration Admin ManagedService, if the Config Admin API is available.
             // Because this fragment is a framework extension, we need to use the wiring API to find the CM API.
             Collection<BundleCapability> providers = fw.findProviders(cmReq);
             for (BundleCapability cap : providers) {
-                if ( registerManagedService(cap)) {
-                    break;
+                if (registerManagedService(cap)) {
+                    return;
                 }
             }
             LOG.log(Level.INFO, "No Configuration Admin API available");
@@ -296,7 +296,7 @@ public class Activator implements BundleActivator, FrameworkListener {
         return null;
     }
 
-    static Requirement createPackageRequirement() {
+    static Requirement createCMPackageRequirement() {
         Requirement cmReq = new Requirement() {
             @Override
             public String getNamespace() {

--- a/src/test/java/org/apache/sling/feature/apiregions/impl/ActivatorTest.java
+++ b/src/test/java/org/apache/sling/feature/apiregions/impl/ActivatorTest.java
@@ -275,7 +275,7 @@ public class ActivatorTest {
 
     @Test
     public void testCreatePackageRequirement() {
-        Requirement req = Activator.createPackageRequirement();
+        Requirement req = Activator.createCMPackageRequirement();
         assertEquals(PackageNamespace.PACKAGE_NAMESPACE, req.getNamespace());
         assertEquals(1, req.getDirectives().size());
         String directive = req.getDirectives().get("filter");


### PR DESCRIPTION
When the Config Admin API is available don't log this message.